### PR TITLE
feature/9_SDCard/71_Data-logging-commands

### DIFF
--- a/DAQ_System/.mbedignore
+++ b/DAQ_System/.mbedignore
@@ -1,0 +1,84 @@
+/* Bootloader */
+mbed-os/features/FEATURE_BOOTLOADER/*
+
+/* BLE */
+mbed-os/connectivity/drivers/ble/*
+mbed-os/connectivity/FEATURE_BLE/*
+
+/* Cellular */
+mbed-os/connectivity/cellular/*
+mbed-os/connectivity/drivers/cellular/*
+mbed-os/connectivity/netsocket/source/Cellular*.*
+
+/* Device Key */
+mbed-os/drivers/device_key/*
+
+/* Experimental /
+mbed-os/platform/FEATURE_EXPERIMENTAL_API/*
+
+/* FPGA */
+mbed-os/features/frameworks/COMPONENT_FPGA_CI_TEST_SHIELD/*
+
+/* LORAWAN */
+mbed-os/connectivity/drivers/lora/*
+mbed-os/connectivity/lorawan/*
+
+/* LWIP */
+mbed-os/connectivity/drivers/emac/*
+mbed-os/connectivity/lwipstack/*
+
+/* Mbed-client-cli */
+mbed-os/features/frameworks/mbed-client-cli/*
+
+/* Storage */
+mbed-os/storage/kvstore/*
+mbed-os/storage/platform/*
+
+/* Unity */
+mbed-os/features/frameworks/unity/*
+
+/* Utest */
+mbed-os/features/frameworks/utest/*
+
+/* USB */
+mbed-os/drivers/usb/source/*
+mbed-os/hal/usb/source/*
+mbed-os/hal/usb/TARGET_Templates/*
+
+/* NFC */
+mbed-os/connectivity/drivers/nfc/*
+mbed-os/connectivity/nfc/*
+
+/* RF */
+mbed-os/connectivity/drivers/802.15.4_RF/*
+
+/* WiFi */
+mbed-os/connectivity/drivers/wifi/*
+
+/* Tests */
+mbed-os/platform/tests/*
+mbed-os/TEST_APPS/*
+mbed-os/TESTS/*
+mbed-os/UNITTESTS/*
+
+/* Greentea client */
+mbed-os/features/frameworks/greentea-client/*
+
+/* MBED TLS */
+mbed-os/connectivity/drivers/mbedtls/*
+mbed-os/connectivity/mbedtls/*
+
+/* Nanostack */
+mbed-os/connectivity/drivers/emac/*
+mbed-os/connectivity/libraries/mbed-coap/*
+mbed-os/connectivity/libraries/nanostack-libservice/*
+mbed-os/connectivity/libraries/ppp/*
+mbed-os/connectivity/nanostack/*
+
+/* Netsocket */
+mbed-os/connectivity/drivers/emac/*
+mbed-os/connectivity/netsocket/*
+mbed-os/connectivity/libraries/mbed-coap/*
+mbed-os/connectivity/libraries/ppp/*
+
+mbed-os/platform/randlib/*

--- a/DAQ_System/Source/Application/DataLogger/SdDataLogger.cpp
+++ b/DAQ_System/Source/Application/DataLogger/SdDataLogger.cpp
@@ -84,8 +84,8 @@ uint8_t SdDataLogger::FileOpen(char* file_path) {
 // closes the given file
 uint8_t SdDataLogger::FileClose() {
     uint8_t status = fclose(data_file_);
-    printf("%s\n", (status < 0 ? "Fail :(" : "OK"));
     if (status < 0) {
+        printf("Fail :(\n");
         error("error: %s (%d)\n", strerror(errno), -errno);
     }
     return status;
@@ -93,7 +93,7 @@ uint8_t SdDataLogger::FileClose() {
 
 // writes the given input to the given file, to allow a specified format, we use sprintf() to print the format to a write_buffer string and then send the write_buffer to file_write()
 uint8_t SdDataLogger::FileWrite(const char* input) {
-    snprintf(write_buffer_, kBlockSectorByteSize, input);
+    snprintf(write_buffer_, kBlockSectorByteSize, "%s", input);
     uint8_t status = fprintf(data_file_, write_buffer_);
     if (status < 0) {
         printf("Fail :(\n");

--- a/DAQ_System/Source/main.cpp
+++ b/DAQ_System/Source/main.cpp
@@ -24,15 +24,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "File.h"
 #include "mbed.h"
-#include <cstdint>
-#include <stdio.h>
-#include <cstdio>
-#include <errno.h>
-
-#include "SDBlockDevice.h"
-#include "FATFileSystem.h"
 
 #include "Application/DataLogger/SdDataLogger.hpp"
 #include "Application/I_Data_Logger.hpp"
@@ -41,7 +33,6 @@
 #define BUFFER_SIZE 21
 
 static InterruptIn button(PC_13);
-
 static bool data_logging_enable = false;
 
 // interrupt routine activated by a falling edge of button input
@@ -86,7 +77,6 @@ int main() {
         // check data logger flag
         if(data_logging_enable) {
 
-
             if(!open_file) {
                 // Create a unique file name
                 for(int i = 0; i < 1000; i++) {
@@ -104,14 +94,11 @@ int main() {
                 }
                 
                 open_file = 1;
-
+                // write the first row to the file with some arbitrary sensor names
+                status = data_logger->FileWrite("Time (sec), LinPot1 (in/s), LinPot2 (in/s), LinPot3 (in/s), LinPot4 (in/s)\n");
             }
 
             printf("Writing to file...\n");
-
-            // write the first row to the file with some arbitrary sensor names
-            status = data_logger->FileWrite("Time (sec), LinPot1 (in/s), LinPot2 (in/s), LinPot3 (in/s), LinPot4 (in/s)\n");
-
             // fill the file with arbitrary numbers (this is just a proof of concept, these are intentionally bs)
             sprintf(write_buffer, "%d,%d,%d,%d,%d\n", timestamp, linpot1, linpot2, linpot3, linpot4);
             status = data_logger->FileWrite(write_buffer);
@@ -121,7 +108,6 @@ int main() {
             linpot4++;
 
             timestamp++;
-
 
         } else if(!data_logging_enable && open_file) {
              // close the file


### PR DESCRIPTION
### Summary
implemented super loop, and push button interrupt handler. The interrupt handler sets a flag that allows data logging, and another local flag tells us whether a file has been opened (so we don't close a null file). This uses the on-board user button on the Nucleo f446re. pushing the button turns data logging on and off

### Remarks
I had this working as intended, then realized I had been in the deliverable branch all along. So I stashed my changes to revert the deliverable branch back to normal, and copied the main.cpp file over to the data logging commands branch. However, this isn't working as I expect it to anymore. I have the right firmware up on mbed studio, but when I upload it to the board (and I can see the lights and it's connected by USB and stuff so I know the firmware is being sent to the board) the board seems to be running the deliverable firmware and not the data logging commands firmware, which makes no sense and shouldn't happen because the changes made in main.cpp for this was pretty significant. Maybe there's just some weird issue with my board or whatever, but this is something to keep in mind if you try to test on your board. I will keep playing with this and see what's going on. However, the code as you see it, was at one point working for me as intended.

### Checks
- [x] Tested
- [ ] Stakeholder approval
