### PR TITLE
Implemented the PE3 ECU library

### DIFF
--- a/Project/DAQ_System/.settings/language.settings.xml
+++ b/Project/DAQ_System/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="1332684046778290836" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1750407751570350087" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="1332684046778290836" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1750407751570350087" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Project/DAQ_System/Program/Src/Platform/CAN/Interfaces/ican.hpp
+++ b/Project/DAQ_System/Program/Src/Platform/CAN/Interfaces/ican.hpp
@@ -32,8 +32,6 @@ public:
 
 	virtual void ClearMessageArrivedFlag() = 0;
 
-	virtual void SubscribeCanId(const std::vector<uint32_t> &can_id_list) = 0;
-
 	virtual uint32_t LatestCanId() = 0;
 
 	virtual void Start() = 0;

--- a/Project/DAQ_System/Program/Src/Platform/CAN/STM/F4/bxcan_stmf4.cpp
+++ b/Project/DAQ_System/Program/Src/Platform/CAN/STM/F4/bxcan_stmf4.cpp
@@ -22,27 +22,20 @@ BxCanStmF4::~BxCanStmF4() {
 	HAL_CAN_Stop(&bx_can_);
 }
 
-void BxCanStmF4::SubscribeCanId(const std::vector<uint32_t> &can_id_list) {
-	CAN_FilterTypeDef filter;
+void BxCanStmF4::ConfigureFilter(uint32_t can_id, uint32_t filder_id_high, uint32_t filter_id_low) {
+	filter_.FilterIdHigh = filder_id_high;
+	filter_.FilterIdLow = (filter_id_low <<3) | CAN_ID_EXT | CAN_RTR_DATA ;
+	filter_.FilterMaskIdHigh = 0xFFFF;
+	filter_.FilterMaskIdLow = 0xFFFF;
+	filter_.FilterFIFOAssignment = CAN_FILTER_FIFO0;
+	filter_.FilterBank = filter_bank_num_;
+	filter_.FilterMode = CAN_FILTERMODE_IDMASK;
+	filter_.FilterScale = CAN_FILTERSCALE_32BIT;
+	filter_.FilterActivation = CAN_FILTER_ENABLE;
+	filter_.SlaveStartFilterBank = 17;
 
-	for (uint8_t i = 0; i < can_id_list.size(); i++) {
-		ConfigureFilter(filter, i, can_id_list.at(i));
-	}
-}
-
-void BxCanStmF4::ConfigureFilter(CAN_FilterTypeDef &filter, uint8_t filter_bank_num, uint32_t can_id) {
-	filter.FilterIdHigh = can_id >> 13 ;
-	filter.FilterIdLow = ((can_id & 0x1FFF) <<3) | CAN_ID_EXT | CAN_RTR_DATA ;
-	filter.FilterMaskIdHigh = 0xFFFF;
-	filter.FilterMaskIdLow = 0xFFFF;
-	filter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
-	filter.FilterBank = filter_bank_num;
-	filter.FilterMode = CAN_FILTERMODE_IDMASK;
-	filter.FilterScale = CAN_FILTERSCALE_32BIT;
-	filter.FilterActivation = CAN_FILTER_ENABLE;
-	filter.SlaveStartFilterBank = 17;
-
-	HAL_CAN_ConfigFilter(&bx_can_, &filter);
+	HAL_CAN_ConfigFilter(&bx_can_, &filter_);
+	filter_bank_num_++;
 }
 
 void BxCanStmF4::Start() {

--- a/Project/DAQ_System/Program/Src/Platform/CAN/STM/F4/bxcan_stmf4.hpp
+++ b/Project/DAQ_System/Program/Src/Platform/CAN/STM/F4/bxcan_stmf4.hpp
@@ -32,8 +32,6 @@ public:
 
 	virtual ~BxCanStmF4();
 
-	virtual void SubscribeCanId(const std::vector<uint32_t> &can_id_list) override;
-
 	virtual void Start() override;
 
 	virtual void EnableInterruptMode() override;
@@ -60,12 +58,13 @@ public:
 		Fifo1Overrun,
 	};
 
+	void ConfigureFilter(uint32_t can_id, uint32_t filder_id_high, uint32_t filter_id_low);
+
 	void ConfigureReceiveCallback(ReceiveInterruptMode mode);
 
 	void ReceiveCallback();
 
 private:
-	void ConfigureFilter(CAN_FilterTypeDef &filter, uint8_t filter_bank_num, uint32_t can_id);
 
 	uint8_t rx_buffer_[kMaxBytes] = { 0 };
 	bool message_arrived_ = false;
@@ -74,6 +73,8 @@ private:
 	// ST's HAL library.
 	CAN_HandleTypeDef& bx_can_; 			// BxCAN (Basic Extended) peripheral
 	CAN_RxHeaderTypeDef rx_message_header_; // Receiving message info
+	CAN_FilterTypeDef filter_;				// Filter bank configuration
+	uint8_t filter_bank_num_;
 
 	// Configurable options
 	uint32_t rx_interrupt_mode_ = 0;

--- a/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/Frames/frame_pe7.hpp
+++ b/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/Frames/frame_pe7.hpp
@@ -23,7 +23,7 @@ public:
 	FramePE7(uint8_t rx_buffer[kByteArrayMaxLength])
 	  : FrameFormat5(rx_buffer) {}
 
-	float AnalogInputVoltage(uint8_t index) {
+	float AnalogInputThermistorVoltage(uint8_t index) {
 		if (index >= kNumOfFields) {
 			return 0.0f;
 		}

--- a/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/iecu.hpp
+++ b/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/iecu.hpp
@@ -12,11 +12,23 @@
 #ifndef IECU_H
 #define IECU_H
 
+#include <vector>
+
 namespace sensor {
 
 class IEcu {
-    public:
-        virtual ~IEcu() = default;
+public:
+	virtual ~IEcu() = default;
+
+	virtual const std::vector<uint32_t>& CanIdList() = 0;
+
+	virtual uint32_t LatestCanId() = 0;
+
+	virtual bool NewMessageArrived() = 0;
+
+	virtual void Update() = 0;
+
+	// TODO: getter methods for each variable
 
 };
 

--- a/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/iecu.hpp
+++ b/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/iecu.hpp
@@ -28,7 +28,27 @@ public:
 
 	virtual void Update() = 0;
 
-	// TODO: getter methods for each variable
+	virtual int16_t Rpm() = 0;
+
+	virtual float Tps() = 0;
+
+	virtual float FuelOpenTime() = 0;
+
+	virtual float IgnitionAngle() = 0;
+
+	virtual float BarometerPressure() = 0;
+
+	virtual float Map() = 0;
+
+	virtual float Lambda() = 0;
+
+	virtual float BatteryVoltage() = 0;
+
+	virtual float AirTemperature() = 0;
+
+	virtual float CoolantTemperature() = 0;
+
+	virtual float AnalogInputVoltage(uint8_t index) = 0;
 
 };
 

--- a/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.cpp
+++ b/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.cpp
@@ -16,11 +16,7 @@
 namespace sensor {
 
 Pe3::Pe3(std::shared_ptr<platform::ICan> can_bus)
-  : can_bus_(can_bus) {
-
-	can_bus_->SubscribeCanId(can_id_list_);
-	can_bus_->Start();
-}
+  : can_bus_(can_bus) { }
 
 Pe3::~Pe3() { }
 

--- a/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.cpp
+++ b/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.cpp
@@ -15,6 +15,202 @@
 
 namespace sensor {
 
+Pe3::Pe3(std::shared_ptr<platform::ICan> can_bus)
+  : can_bus_(can_bus) {
+
+	can_bus_->SubscribeCanId(can_id_list_);
+	can_bus_->Start();
+}
+
+Pe3::~Pe3() { }
+
+const std::vector<uint32_t>& Pe3::CanIdList() {
+	return can_id_list_;
+}
+
+uint32_t Pe3::LatestCanId() {
+	return can_bus_->LatestCanId();
+}
+
+bool Pe3::NewMessageArrived() {
+	return can_bus_->MessageArrivedFlag();
+}
+
+void Pe3::Update() {
+	can_bus_->Receive(raw_data_);
+
+	switch(can_bus_->LatestCanId()) {
+	case FramePe1Id:
+		ProcessFramePe1();
+		break;
+	case FramePe2Id:
+		ProcessFramePe2();
+		break;
+	case FramePe3Id:
+		ProcessFramePe3();
+		break;
+	case FramePe4Id:
+		ProcessFramePe4();
+		break;
+	case FramePe5Id:
+		ProcessFramePe5();
+		break;
+	case FramePe6Id:
+		ProcessFramePe6();
+		break;
+	case FramePe7Id:
+		ProcessFramePe7();
+		break;
+	case FramePe8Id:
+		ProcessFramePe8();
+		break;
+	case FramePe9Id:
+		ProcessFramePe9();
+		break;
+	case FramePe10Id:
+		ProcessFramePe10();
+		break;
+	case FramePe11Id:
+		ProcessFramePe11();
+		break;
+	case FramePe12Id:
+		ProcessFramePe12();
+		break;
+	case FramePe13Id:
+		ProcessFramePe13();
+		break;
+	case FramePe14Id:
+		ProcessFramePe14();
+		break;
+	case FramePe15Id:
+		ProcessFramePe15();
+		break;
+	case FramePe16Id:
+		ProcessFramePe16();
+		break;
+	}
+
+	can_bus_->ClearMessageArrivedFlag();
+}
+
+void Pe3::ProcessFramePe1() {
+	FramePE1 frame(raw_data_);
+	rpm_ = frame.RevolutionsPerMinute();
+	tps_ = frame.ThrottlePosition();
+	fuel_open_time_ = frame.FuelOpenTime();
+	ignition_angle_ = frame.IgnitionAngle();
+}
+
+void Pe3::ProcessFramePe2() {
+	FramePE2 frame(raw_data_);
+	barometer_pressure_ = frame.BarometerPressure();
+	map_ = frame.ManifoldAbsolutePressure();
+	lambda_ = frame.Lambda();
+	pressure_unit = frame.PressureUnit();
+}
+
+void Pe3::ProcessFramePe3() {
+	FramePE3 frame(raw_data_);
+	for (int i = 0; i < frame.kNumOfFields; i++) {
+		analog_inputs_[i] = frame.AnalogInputVoltage(i);
+	}
+}
+
+void Pe3::ProcessFramePe4() {
+	FramePE4 frame(raw_data_);
+	static constexpr uint8_t offset = 4;
+	for (int i = 0; i < frame.kNumOfFields; i++) {
+		analog_inputs_[i + offset] = frame.AnalogInputVoltage(i);
+	}
+}
+
+void Pe3::ProcessFramePe5() {
+	FramePE5 frame(raw_data_);
+	for (int i = 0; i < frame.kNumOfFields; i++) {
+		frequencies_[i] = frame.FrequencyHertz(i);
+	}
+}
+
+void Pe3::ProcessFramePe6() {
+	FramePE6 frame(raw_data_);
+	battery_voltage_ = frame.BatteryVoltage();
+	air_temp_ = frame.AirTemperature();
+	coolant_temp_ = frame.CoolantTemperature();
+	temperature_unit_ = frame.TemperatureUnit();
+}
+
+void Pe3::ProcessFramePe7() {
+	FramePE7 frame(raw_data_);
+	analog_inputs_thermistors_[0] = frame.AnalogInputVoltage(0);
+	analog_inputs_thermistors_[1] = frame.AnalogInputVoltage(1);
+}
+
+void Pe3::ProcessFramePe8() {
+	FramePE8 frame(raw_data_);
+	rpm_rate_ = frame.RevolutionsPerMinuteRate();
+	tps_rate_ = frame.ThrottlePositionPercentageRate();
+	map_rate_ = frame.ManifoldAbsolutePressureRate();
+	maf_load_rate_ = frame.MassAirFlowLoadRate();
+}
+
+void Pe3::ProcessFramePe9() {
+	FramePE9 frame(raw_data_);
+	measured_lambda_1_ = frame.LambdaMeasured(0);
+	measured_lambda_2_ = frame.LambdaMeasured(1);
+	target_lambda_ = frame.TargetLambda();
+}
+
+void Pe3::ProcessFramePe10() {
+	FramePE10 frame(raw_data_);
+	for (int i = 0; i < frame.kNumOfFields; i++) {
+		duty_cycles_[i] = frame.PwmDutyCycle(i);
+	}
+}
+
+void Pe3::ProcessFramePe11() {
+	FramePE11 frame(raw_data_);
+	percent_slip_ = frame.PercentSlip();
+	driven_wheel_rate_ = frame.DrivenWheelRateOfChange();
+	desired_value_ = frame.DesiredValue();
+}
+
+void Pe3::ProcessFramePe12() {
+	FramePE12 frame(raw_data_);
+	driven_avg_wheel_speed_ = frame.DrivenAverageWheelSpeed();
+	nondriven_avg_wheel_speed_ = frame.NonDrivenAverageWheelSpeed();
+	ignition_compensation_ = frame.IgnitionCompensation();
+	ignition_cut_percentage_ = frame.IgnitionCutPercentage();
+}
+
+void Pe3::ProcessFramePe13() {
+	FramePE13 frame(raw_data_);
+	driven_wheel_speed_1_ = frame.DrivenWheelSpeed(0);
+	driven_wheel_speed_2_ = frame.DrivenWheelSpeed(1);
+	nondriven_wheel_speed_1_ = frame.NonDrivenWheelSpeed(0);
+	nondriven_wheel_speed_2_ = frame.NonDrivenWheelSpeed(1);
+}
+
+void Pe3::ProcessFramePe14() {
+	FramePE14 frame(raw_data_);
+	fuel_comp_acceleration_ = frame.FuelCompensationAcceleration();
+	fuel_comp_starting_ = frame.FuelCompensationStarting();
+	fuel_comp_air_temp_ = frame.FuelCompensationAirTemperature();
+	fuel_comp_coolant_temp_ = frame.FuelCompensationCoolantTemperature();
+}
+
+void Pe3::ProcessFramePe15() {
+	FramePE15 frame(raw_data_);
+	fuel_comp_barometer_ = frame.FuelCompensationBarometer();
+	fuel_comp_map_ = frame.FuelCompensationManifoldAbsolutePressure();
+}
+
+void Pe3::ProcessFramePe16() {
+	FramePE16 frame(raw_data_);
+	ignition_comp_air_temp_ = frame.IgnitionCompensationAirTemperature();
+	ignition_comp_coolant_temp_ = frame.IgnitionCompensationCoolantTemperature();
+	ignition_comp_barometer_ = frame.IgnitionCompensationBarometer();
+	ignition_comp_map_ = frame.IgnitionCompensationManifoldAbsolutePressure();
+}
 
 
 }

--- a/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.cpp
+++ b/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.cpp
@@ -36,6 +36,87 @@ bool Pe3::NewMessageArrived() {
 	return can_bus_->MessageArrivedFlag();
 }
 
+
+int16_t Pe3::Rpm() { return rpm_; }
+
+float Pe3::Tps() { return tps_; }
+
+float Pe3::FuelOpenTime() { return fuel_open_time_; }
+
+float Pe3::IgnitionAngle() { return ignition_angle_; }
+
+float Pe3::BarometerPressure() { return barometer_pressure_; }
+
+float Pe3::Map() { return map_; }
+
+float Pe3::Lambda() { return lambda_; }
+
+float Pe3::AnalogInputVoltage(uint8_t index) { return analog_inputs_.at(index); }
+
+float Pe3::BatteryVoltage() { return battery_voltage_; }
+
+float Pe3::AirTemperature() { return air_temp_; }
+
+float Pe3::CoolantTemperature() { return coolant_temp_; }
+
+// TODO: get temperature and pressure types
+// TODO: access arrays using .at() for bounds checking
+
+float Pe3::FrequencyHertz(uint8_t index) { return frequencies_.at(index); }
+
+float Pe3::AnalogInputThermistorVoltage(uint8_t index) { return analog_inputs_thermistors_.at(index); }
+
+float Pe3::RpmRate() { return rpm_rate_; }
+
+float Pe3::TpsPercentageRate() { return tps_rate_; }
+
+float Pe3::MapRate() { return map_rate_; }
+
+float Pe3::MassAirFlowLoadRate() { return maf_load_rate_; }
+
+float Pe3::LambdaMeasured(uint8_t index) { return measured_lambdas_.at(index); }
+
+float Pe3::PwmDutyCycle(uint8_t index) { return duty_cycles_.at(index); }
+
+float Pe3::PercentSlip() { return percent_slip_; }
+
+float Pe3::DrivenWheelRateOfChange() { return driven_wheel_rate_; }
+
+float Pe3::DesiredValue() { return desired_value_; }
+
+float Pe3::DrivenAverageWheelSpeed() { return driven_avg_wheel_speed_; }
+
+float Pe3::NonDrivenAverageWheelSpeed() { return nondriven_avg_wheel_speed_; }
+
+float Pe3::IgnitionCompensation() { return ignition_compensation_; }
+
+float Pe3::IgnitionCutPercentage() { return ignition_cut_percentage_; }
+
+float Pe3::DrivenWheelSpeed(uint8_t index) { return driven_wheel_speeds_.at(index); }
+
+float Pe3::NonDrivenWheelSpeed(uint8_t index) { return nondriven_wheel_speeds_.at(index); }
+
+float Pe3::FuelCompensationAcceleration() { return fuel_comp_acceleration_; }
+
+float Pe3::FuelCompensationStarting() { return fuel_comp_starting_; }
+
+float Pe3::FuelCompensationAirTemperature() { return fuel_comp_air_temp_; }
+
+float Pe3::FuelCompensationCoolantTemperature() { return fuel_comp_coolant_temp_; }
+
+float Pe3::FuelCompensationBarometer() { return fuel_comp_barometer_; }
+
+float Pe3::FuelCompensationManifoldAbsolutePressure() { return fuel_comp_map_; }
+
+float Pe3::IgnitionCompensationAirTemperature() { return ignition_comp_air_temp_; }
+
+float Pe3::IgnitionCompensationCoolantTemperature() { return ignition_comp_coolant_temp_; }
+
+float Pe3::IgnitionCompensationBarometer() { return ignition_comp_barometer_; }
+
+float Pe3::IgnitionCompensationManifoldAbsolutePressure() { return ignition_comp_map_; }
+
+
 void Pe3::Update() {
 	can_bus_->Receive(raw_data_);
 
@@ -155,8 +236,8 @@ void Pe3::ProcessFramePe8() {
 
 void Pe3::ProcessFramePe9() {
 	FramePE9 frame(raw_data_);
-	measured_lambda_1_ = frame.LambdaMeasured(0);
-	measured_lambda_2_ = frame.LambdaMeasured(1);
+	measured_lambdas_.at(0) = frame.LambdaMeasured(0);
+	measured_lambdas_.at(1) = frame.LambdaMeasured(1);
 	target_lambda_ = frame.TargetLambda();
 }
 
@@ -184,10 +265,10 @@ void Pe3::ProcessFramePe12() {
 
 void Pe3::ProcessFramePe13() {
 	FramePE13 frame(raw_data_);
-	driven_wheel_speed_1_ = frame.DrivenWheelSpeed(0);
-	driven_wheel_speed_2_ = frame.DrivenWheelSpeed(1);
-	nondriven_wheel_speed_1_ = frame.NonDrivenWheelSpeed(0);
-	nondriven_wheel_speed_2_ = frame.NonDrivenWheelSpeed(1);
+	driven_wheel_speeds_.at(0) = frame.DrivenWheelSpeed(0);
+	driven_wheel_speeds_.at(1) = frame.DrivenWheelSpeed(1);
+	nondriven_wheel_speeds_.at(0) = frame.NonDrivenWheelSpeed(0);
+	nondriven_wheel_speeds_.at(1) = frame.NonDrivenWheelSpeed(1);
 }
 
 void Pe3::ProcessFramePe14() {
@@ -213,5 +294,6 @@ void Pe3::ProcessFramePe16() {
 }
 
 
-}
+
+} // namespace sensor
 

--- a/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.cpp
+++ b/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.cpp
@@ -59,8 +59,9 @@ float Pe3::AirTemperature() { return air_temp_; }
 
 float Pe3::CoolantTemperature() { return coolant_temp_; }
 
-// TODO: get temperature and pressure types
-// TODO: access arrays using .at() for bounds checking
+PressureType Pe3::PressureUnit() { return pressure_unit_; }
+
+TemperatureType Pe3::TemperatureUnit() { return temperature_unit_; }
 
 float Pe3::FrequencyHertz(uint8_t index) { return frequencies_.at(index); }
 
@@ -187,13 +188,13 @@ void Pe3::ProcessFramePe2() {
 	barometer_pressure_ = frame.BarometerPressure();
 	map_ = frame.ManifoldAbsolutePressure();
 	lambda_ = frame.Lambda();
-	pressure_unit = frame.PressureUnit();
+	pressure_unit_ = frame.PressureUnit();
 }
 
 void Pe3::ProcessFramePe3() {
 	FramePE3 frame(raw_data_);
 	for (int i = 0; i < frame.kNumOfFields; i++) {
-		analog_inputs_[i] = frame.AnalogInputVoltage(i);
+		analog_inputs_.at(i) = frame.AnalogInputVoltage(i);
 	}
 }
 
@@ -201,14 +202,14 @@ void Pe3::ProcessFramePe4() {
 	FramePE4 frame(raw_data_);
 	static constexpr uint8_t offset = 4;
 	for (int i = 0; i < frame.kNumOfFields; i++) {
-		analog_inputs_[i + offset] = frame.AnalogInputVoltage(i);
+		analog_inputs_.at(i + offset) = frame.AnalogInputVoltage(i);
 	}
 }
 
 void Pe3::ProcessFramePe5() {
 	FramePE5 frame(raw_data_);
 	for (int i = 0; i < frame.kNumOfFields; i++) {
-		frequencies_[i] = frame.FrequencyHertz(i);
+		frequencies_.at(i) = frame.FrequencyHertz(i);
 	}
 }
 
@@ -222,8 +223,8 @@ void Pe3::ProcessFramePe6() {
 
 void Pe3::ProcessFramePe7() {
 	FramePE7 frame(raw_data_);
-	analog_inputs_thermistors_[0] = frame.AnalogInputVoltage(0);
-	analog_inputs_thermistors_[1] = frame.AnalogInputVoltage(1);
+	analog_inputs_thermistors_.at(0) = frame.AnalogInputThermistorVoltage(0);
+	analog_inputs_thermistors_.at(1) = frame.AnalogInputThermistorVoltage(1);
 }
 
 void Pe3::ProcessFramePe8() {
@@ -244,7 +245,7 @@ void Pe3::ProcessFramePe9() {
 void Pe3::ProcessFramePe10() {
 	FramePE10 frame(raw_data_);
 	for (int i = 0; i < frame.kNumOfFields; i++) {
-		duty_cycles_[i] = frame.PwmDutyCycle(i);
+		duty_cycles_.at(i) = frame.PwmDutyCycle(i);
 	}
 }
 
@@ -293,7 +294,4 @@ void Pe3::ProcessFramePe16() {
 	ignition_comp_map_ = frame.IgnitionCompensationManifoldAbsolutePressure();
 }
 
-
-
 } // namespace sensor
-

--- a/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.hpp
+++ b/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.hpp
@@ -62,7 +62,7 @@ namespace sensor {
 #define FramePe15Id		0x0CFFFE48
 #define FramePe16Id		0x0CFFD048
 
-class Pe3 : IEcu {
+class Pe3 : public IEcu {
 public:
 	Pe3(std::shared_ptr<platform::ICan> can_bus);
 
@@ -76,83 +76,85 @@ public:
 
 	void Update() override;
 
-	// Frame PE1 Fields
-	uint16_t rpm_ = 0;
-	float tps_ = 0.0f;
-	float fuel_open_time_ = 0.0f;
-	float ignition_angle_ = 0.0f;
+	int16_t Rpm() override;
 
-	// Frame PE2 Fields
-	float barometer_pressure_ = 0.0f;
-	float map_ = 0.0f;
-	float lambda_ = 0.0f;
-	PressureType pressure_unit = PressureType::kUnknown;
+	float Tps() override;
 
-	// Frame PE3 and PE4 Fields
-	static constexpr uint8_t kNumAnalogPorts = 8;
-	std::array<float, kNumAnalogPorts> analog_inputs_;
+	float FuelOpenTime() override;
 
-	//Frame PE5 Fields
-	static constexpr uint8_t kNumFrequencyPorts = 4;
-	std::array<float, kNumFrequencyPorts> frequencies_;
+	float IgnitionAngle() override;
 
-	// Frame PE6 Fields
-	float battery_voltage_ = 0.0f;
-	float air_temp_ = 0.0f;
-	float coolant_temp_ = 0.0f;
-	TemperatureType temperature_unit_ = TemperatureType::kUnknown;
+	float BarometerPressure() override;
 
-	// Frame PE7 Fields
-	static constexpr uint8_t kNumAnalogThermistorPorts = 2;
-	std::array<float, kNumAnalogThermistorPorts> analog_inputs_thermistors_;
+	float Map() override;
 
-	// Frame PE8 Fields
-	float rpm_rate_ = 0.0f;
-	float tps_rate_ = 0.0f;
-	float map_rate_ = 0.0f;
-	float maf_load_rate_ = 0.0f;
+	float Lambda() override;
 
-	// Frame PE9 Fields
-	float measured_lambda_1_ = 0.0f;
-	float measured_lambda_2_ = 0.0f;
-	float target_lambda_ = 0.0f;
+	float AnalogInputVoltage(uint8_t index) override;
 
-	// Frame PE10 Fields
-	static constexpr uint8_t kNumDutyCyclePorts = 8;
-	std::array<float, kNumDutyCyclePorts> duty_cycles_;
+	float BatteryVoltage() override;
 
-	// Frame PE11 Fields
-	float percent_slip_ = 0.0f;
-	float driven_wheel_rate_ = 0.0f;
-	float desired_value_ = 0.0f;
+	float AirTemperature() override;
 
-	// Frame PE12 Fields
-	float driven_avg_wheel_speed_ = 0.0f;
-	float nondriven_avg_wheel_speed_ = 0.0f;
-	float ignition_compensation_ = 0.0f;
-	float ignition_cut_percentage_ = 0.0f;
+	float CoolantTemperature() override;
 
-	// Frame PE13 Fields
-	float driven_wheel_speed_1_ = 0.0f;
-	float driven_wheel_speed_2_ = 0.0f;
-	float nondriven_wheel_speed_1_ = 0.0f;
-	float nondriven_wheel_speed_2_ = 0.0f;
+	//--------
 
-	// Frame PE14 Fields
-	float fuel_comp_acceleration_ = 0.0f;
-	float fuel_comp_starting_ = 0.0f;
-	float fuel_comp_air_temp_ = 0.0f;
-	float fuel_comp_coolant_temp_ = 0.0f;
+	// TODO: get temperature and pressure types
 
-	// Frame PE15 Fields
-	float fuel_comp_barometer_ = 0.0f;
-	float fuel_comp_map_ = 0.0f;
+	float FrequencyHertz(uint8_t index);
 
-	// Frame PE16 Fields
-	float ignition_comp_air_temp_ = 0.0f;
-	float ignition_comp_coolant_temp_ = 0.0f;
-	float ignition_comp_barometer_ = 0.0f;
-	float ignition_comp_map_ = 0.0f;
+	float AnalogInputThermistorVoltage(uint8_t index);
+
+	float RpmRate();
+
+	float TpsPercentageRate();
+
+	float MapRate();
+
+	float MassAirFlowLoadRate();
+
+	float LambdaMeasured(uint8_t index);
+
+	float PwmDutyCycle(uint8_t index);
+
+	float PercentSlip();
+
+	float DrivenWheelRateOfChange();
+
+	float DesiredValue();
+
+	float DrivenAverageWheelSpeed();
+
+	float NonDrivenAverageWheelSpeed();
+
+	float IgnitionCompensation();
+
+	float IgnitionCutPercentage();
+
+	float DrivenWheelSpeed(uint8_t index);
+
+	float NonDrivenWheelSpeed(uint8_t index);
+
+	float FuelCompensationAcceleration();
+
+	float FuelCompensationStarting();
+
+	float FuelCompensationAirTemperature();
+
+	float FuelCompensationCoolantTemperature();
+
+	float FuelCompensationBarometer();
+
+	float FuelCompensationManifoldAbsolutePressure();
+
+	float IgnitionCompensationAirTemperature();
+
+	float IgnitionCompensationCoolantTemperature();
+
+	float IgnitionCompensationBarometer();
+
+	float IgnitionCompensationManifoldAbsolutePressure();
 
 
 private:
@@ -192,6 +194,83 @@ private:
 
 	std::shared_ptr<platform::ICan> can_bus_;
 	uint8_t raw_data_[8];
+
+	// Frame PE1 Fields
+	uint16_t rpm_ = 0;
+	float tps_ = 0.0f;
+	float fuel_open_time_ = 0.0f;
+	float ignition_angle_ = 0.0f;
+
+	// Frame PE2 Fields
+	float barometer_pressure_ = 0.0f;
+	float map_ = 0.0f;
+	float lambda_ = 0.0f;
+	PressureType pressure_unit = PressureType::kUnknown;
+
+	// Frame PE3 and PE4 Fields
+	static constexpr uint8_t kNumAnalogPorts = 8;
+	std::array<float, kNumAnalogPorts> analog_inputs_;
+
+	//Frame PE5 Fields
+	static constexpr uint8_t kNumFrequencyPorts = 4;
+	std::array<float, kNumFrequencyPorts> frequencies_;
+
+	// Frame PE6 Fields
+	float battery_voltage_ = 0.0f;
+	float air_temp_ = 0.0f;
+	float coolant_temp_ = 0.0f;
+	TemperatureType temperature_unit_ = TemperatureType::kUnknown;
+
+	// Frame PE7 Fields
+	static constexpr uint8_t kNumAnalogThermistorPorts = 2;
+	std::array<float, kNumAnalogThermistorPorts> analog_inputs_thermistors_;
+
+	// Frame PE8 Fields
+	float rpm_rate_ = 0.0f;
+	float tps_rate_ = 0.0f;
+	float map_rate_ = 0.0f;
+	float maf_load_rate_ = 0.0f;
+
+	// Frame PE9 Fields
+	static constexpr uint8_t kNumMeasuredLambda = 2;
+	std::array<float, kNumMeasuredLambda> measured_lambdas_;
+	float target_lambda_ = 0.0f;
+
+	// Frame PE10 Fields
+	static constexpr uint8_t kNumDutyCyclePorts = 8;
+	std::array<float, kNumDutyCyclePorts> duty_cycles_;
+
+	// Frame PE11 Fields
+	float percent_slip_ = 0.0f;
+	float driven_wheel_rate_ = 0.0f;
+	float desired_value_ = 0.0f;
+
+	// Frame PE12 Fields
+	float driven_avg_wheel_speed_ = 0.0f;
+	float nondriven_avg_wheel_speed_ = 0.0f;
+	float ignition_compensation_ = 0.0f;
+	float ignition_cut_percentage_ = 0.0f;
+
+	// Frame PE13 Fields
+	static constexpr uint8_t kNumWheelSpeeds = 2;
+	std::array<float, kNumWheelSpeeds> driven_wheel_speeds_;
+	std::array<float, kNumWheelSpeeds> nondriven_wheel_speeds_;
+
+	// Frame PE14 Fields
+	float fuel_comp_acceleration_ = 0.0f;
+	float fuel_comp_starting_ = 0.0f;
+	float fuel_comp_air_temp_ = 0.0f;
+	float fuel_comp_coolant_temp_ = 0.0f;
+
+	// Frame PE15 Fields
+	float fuel_comp_barometer_ = 0.0f;
+	float fuel_comp_map_ = 0.0f;
+
+	// Frame PE16 Fields
+	float ignition_comp_air_temp_ = 0.0f;
+	float ignition_comp_coolant_temp_ = 0.0f;
+	float ignition_comp_barometer_ = 0.0f;
+	float ignition_comp_map_ = 0.0f;
 };
 
 } // namespace sensor

--- a/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.hpp
+++ b/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.hpp
@@ -98,9 +98,9 @@ public:
 
 	float CoolantTemperature() override;
 
-	//--------
+	PressureType PressureUnit();
 
-	// TODO: get temperature and pressure types
+	TemperatureType TemperatureUnit();
 
 	float FrequencyHertz(uint8_t index);
 
@@ -205,7 +205,7 @@ private:
 	float barometer_pressure_ = 0.0f;
 	float map_ = 0.0f;
 	float lambda_ = 0.0f;
-	PressureType pressure_unit = PressureType::kUnknown;
+	PressureType pressure_unit_ = PressureType::kUnknown;
 
 	// Frame PE3 and PE4 Fields
 	static constexpr uint8_t kNumAnalogPorts = 8;

--- a/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.hpp
+++ b/Project/DAQ_System/Program/Src/Sensor/ECU/PE3/pe3.hpp
@@ -14,12 +14,186 @@
 #ifndef ECU_PE3_PE3_H
 #define ECU_PE3_PE3_H
 
+// Standard Libraries
+#include <inttypes.h>
+
+#include <vector>
+#include <array>
+#include <memory>
+
+// DFR Custom Dependencies
+#include "iecu.hpp"
+#include "../../../Platform/CAN/Interfaces/ican.hpp"
+
+// Internal ECU Messages
+#include "Frames/frame_pe1.hpp"
+#include "Frames/frame_pe2.hpp"
+#include "Frames/frame_pe3.hpp"
+#include "Frames/frame_pe4.hpp"
+#include "Frames/frame_pe5.hpp"
+#include "Frames/frame_pe6.hpp"
+#include "Frames/frame_pe7.hpp"
+#include "Frames/frame_pe8.hpp"
+#include "Frames/frame_pe9.hpp"
+#include "Frames/frame_pe10.hpp"
+#include "Frames/frame_pe11.hpp"
+#include "Frames/frame_pe12.hpp"
+#include "Frames/frame_pe13.hpp"
+#include "Frames/frame_pe14.hpp"
+#include "Frames/frame_pe15.hpp"
+#include "Frames/frame_pe16.hpp"
+
 namespace sensor {
 
-class Pe3 {
+#define FramePe1Id		0x0CFFF048
+#define FramePe2Id		0x0CFFF148
+#define FramePe3Id		0x0CFFF248
+#define FramePe4Id		0x0CFFF348
+#define FramePe5Id		0x0CFFF448
+#define FramePe6Id		0x0CFFF548
+#define FramePe7Id		0x0CFFF648
+#define FramePe8Id		0x0CFFF748
+#define FramePe9Id		0x0CFFF848
+#define FramePe10Id		0x0CFFF948
+#define FramePe11Id		0x0CFFFA48
+#define FramePe12Id		0x0CFFFB48
+#define FramePe13Id		0x0CFFFC48
+#define FramePe14Id		0x0CFFFD48
+#define FramePe15Id		0x0CFFFE48
+#define FramePe16Id		0x0CFFD048
 
+class Pe3 : IEcu {
+public:
+	Pe3(std::shared_ptr<platform::ICan> can_bus);
+
+	virtual ~Pe3();
+
+	const std::vector<uint32_t>& CanIdList() override;
+
+	uint32_t LatestCanId() override;
+
+	bool NewMessageArrived() override;
+
+	void Update() override;
+
+	// Frame PE1 Fields
+	uint16_t rpm_ = 0;
+	float tps_ = 0.0f;
+	float fuel_open_time_ = 0.0f;
+	float ignition_angle_ = 0.0f;
+
+	// Frame PE2 Fields
+	float barometer_pressure_ = 0.0f;
+	float map_ = 0.0f;
+	float lambda_ = 0.0f;
+	PressureType pressure_unit = PressureType::kUnknown;
+
+	// Frame PE3 and PE4 Fields
+	static constexpr uint8_t kNumAnalogPorts = 8;
+	std::array<float, kNumAnalogPorts> analog_inputs_;
+
+	//Frame PE5 Fields
+	static constexpr uint8_t kNumFrequencyPorts = 4;
+	std::array<float, kNumFrequencyPorts> frequencies_;
+
+	// Frame PE6 Fields
+	float battery_voltage_ = 0.0f;
+	float air_temp_ = 0.0f;
+	float coolant_temp_ = 0.0f;
+	TemperatureType temperature_unit_ = TemperatureType::kUnknown;
+
+	// Frame PE7 Fields
+	static constexpr uint8_t kNumAnalogThermistorPorts = 2;
+	std::array<float, kNumAnalogThermistorPorts> analog_inputs_thermistors_;
+
+	// Frame PE8 Fields
+	float rpm_rate_ = 0.0f;
+	float tps_rate_ = 0.0f;
+	float map_rate_ = 0.0f;
+	float maf_load_rate_ = 0.0f;
+
+	// Frame PE9 Fields
+	float measured_lambda_1_ = 0.0f;
+	float measured_lambda_2_ = 0.0f;
+	float target_lambda_ = 0.0f;
+
+	// Frame PE10 Fields
+	static constexpr uint8_t kNumDutyCyclePorts = 8;
+	std::array<float, kNumDutyCyclePorts> duty_cycles_;
+
+	// Frame PE11 Fields
+	float percent_slip_ = 0.0f;
+	float driven_wheel_rate_ = 0.0f;
+	float desired_value_ = 0.0f;
+
+	// Frame PE12 Fields
+	float driven_avg_wheel_speed_ = 0.0f;
+	float nondriven_avg_wheel_speed_ = 0.0f;
+	float ignition_compensation_ = 0.0f;
+	float ignition_cut_percentage_ = 0.0f;
+
+	// Frame PE13 Fields
+	float driven_wheel_speed_1_ = 0.0f;
+	float driven_wheel_speed_2_ = 0.0f;
+	float nondriven_wheel_speed_1_ = 0.0f;
+	float nondriven_wheel_speed_2_ = 0.0f;
+
+	// Frame PE14 Fields
+	float fuel_comp_acceleration_ = 0.0f;
+	float fuel_comp_starting_ = 0.0f;
+	float fuel_comp_air_temp_ = 0.0f;
+	float fuel_comp_coolant_temp_ = 0.0f;
+
+	// Frame PE15 Fields
+	float fuel_comp_barometer_ = 0.0f;
+	float fuel_comp_map_ = 0.0f;
+
+	// Frame PE16 Fields
+	float ignition_comp_air_temp_ = 0.0f;
+	float ignition_comp_coolant_temp_ = 0.0f;
+	float ignition_comp_barometer_ = 0.0f;
+	float ignition_comp_map_ = 0.0f;
+
+
+private:
+	void ProcessFramePe1();
+	void ProcessFramePe2();
+	void ProcessFramePe3();
+	void ProcessFramePe4();
+	void ProcessFramePe5();
+	void ProcessFramePe6();
+	void ProcessFramePe7();
+	void ProcessFramePe8();
+	void ProcessFramePe9();
+	void ProcessFramePe10();
+	void ProcessFramePe11();
+	void ProcessFramePe12();
+	void ProcessFramePe13();
+	void ProcessFramePe14();
+	void ProcessFramePe15();
+	void ProcessFramePe16();
+
+	const std::vector<uint32_t> can_id_list_ = {  //FramePe1Id,
+												  FramePe2Id,
+												  //FramePe3Id,
+												  //FramePe4Id,
+												  //FramePe5Id,
+												  FramePe6Id,
+												  //FramePe7Id,
+												  //FramePe8Id,
+												  //FramePe9Id,
+												  //FramePe10Id,
+												  //FramePe11Id,
+												  //FramePe12Id,
+												  //FramePe13Id,
+												  //FramePe14Id,
+												  //FramePe15Id,
+												  FramePe16Id  };
+
+	std::shared_ptr<platform::ICan> can_bus_;
+	uint8_t raw_data_[8];
 };
 
-}
+} // namespace sensor
 
 #endif // ECU_PE3_PE3_H

--- a/Project/DAQ_System/Program/Src/app.cpp
+++ b/Project/DAQ_System/Program/Src/app.cpp
@@ -35,9 +35,10 @@ extern I2C_HandleTypeDef hi2c1;
 #include "Platform/CAN/STM/F4/bxcan_stmf4.hpp"
 #include "Platform/CAN/Interfaces/ican.hpp"
 #include "Sensor/Accelerometer/lsm303dlhc.hpp"
+#include "Sensor/ECU/PE3/iecu.hpp"
+#include "Sensor/ECU/PE3/pe3.hpp"
 #include "Sensor/GyroScope/igyroscope.hpp"
 #include "Sensor/GyroScope/l3gd20h.hpp"
-#include "Sensor/ECU/PE3/Frames/frame_pe2.hpp"
 #include "Sensor/LinearPotentiometer/ilinear_potentiometer.hpp"
 #include "Sensor/LinearPotentiometer/sls1322.hpp"
 
@@ -68,40 +69,17 @@ void cppMain() {
 
 
 
+	auto bx_can_peripheral = std::make_shared<platform::BxCanStmF4>(hcan1);
 
-	std::vector<uint32_t> can_id_list = { 0x0CFFF048,
-										  0x0CFFF148,
-										//   0x0CFFF248,
-										//   0x0CFFF348,
-										//   0x0CFFF448,
-										  0x0CFFF548,
-										//   0x0CFFF648,
-										//   0x0CFFF748,
-										//   0x0CFFF848,
-										//   0x0CFFF948,
-										//   0x0CFFFA48,
-										//   0x0CFFFB48,
-										//   0x0CFFFC48,
-										//   0x0CFFFD48,
-										//   0x0CFFFE48,
-										  0x0CFFD048  };
-
-	std::shared_ptr<platform::BxCanStmF4> bx_can_peripheral(nullptr);
-	bx_can_peripheral = std::make_shared<platform::BxCanStmF4>(hcan1);
-	bx_can_peripheral->SubscribeCanId(can_id_list);
-	bx_can_peripheral->Start();
-
-	ReceiveInterruptMode rx_interrupt_mode = ReceiveInterruptMode::kFifo0MessagePending;
-	bx_can_peripheral->ConfigureReceiveCallback(rx_interrupt_mode);
+	auto ecu = std::make_unique<sensor::Pe3>(bx_can_peripheral);
 
 	bx_can_callback_ptr = bx_can_peripheral;
+	ReceiveInterruptMode rx_interrupt_mode = ReceiveInterruptMode::kFifo0MessagePending;
+	bx_can_peripheral->ConfigureReceiveCallback(rx_interrupt_mode);
+	bx_can_peripheral->EnableInterruptMode();
 
-	std::shared_ptr<platform::ICan> can_bus(nullptr);
-	can_bus = bx_can_peripheral;
-	// TODO: pass `can_bus` to ECU component via constructor
-	can_bus->EnableInterruptMode();
 
-	uint8_t rx_buffer[8];
+	float manifold_absolute_pressure = 0.0f;
 
 //	float displacement_inches = 0.0f;
 //	float* acc_data = 0.0f;
@@ -133,30 +111,32 @@ void cppMain() {
 
 
 
-		//HAL_Delay(150);
-		if(can_bus->MessageArrivedFlag()){
+		if (ecu->NewMessageArrived()) {
 			__disable_irq();
-//			can_bus->DisableInterruptMode();
-			can_bus->Receive(rx_buffer);
 
-			if(can_bus->LatestCanId() == 0x0CFFF148) {
-				sensor::FramePE2 frame(rx_buffer);
-				float manifold_absolute_pressure = frame.ManifoldAbsolutePressure();
+			ecu->Update();
+			uint32_t can_id = ecu->LatestCanId();
 
-				printf("\t\t 0x0CFFF148 \n");
+			switch(can_id) {
+			case FramePe2Id:
+				manifold_absolute_pressure = ecu->map_;
+
+				printf("\t\t %" PRIu32 "\n", can_id);
 				printf("Manifold Pressure: %f\n", manifold_absolute_pressure);
 				printf("\r");
+				break;
 
-			} else if(can_bus->LatestCanId() == 0x0CFFF548){
-				printf("\t\t 0x0CFFF548 \n");
-				printf("\r");
-				// Process raw data
+
+			case FramePe6Id:
+				printf("\t\t %" PRIu32 "\n", can_id);
+				break;
 			}
 
-			can_bus->ClearMessageArrivedFlag();
-//			can_bus->EnableInterruptMode();
 			__enable_irq();
 		}
+
+		//HAL_Delay(150);
+
 	}
 }
 

--- a/Project/DAQ_System/Program/Src/app.cpp
+++ b/Project/DAQ_System/Program/Src/app.cpp
@@ -69,10 +69,17 @@ void cppMain() {
 
 
 	auto bx_can_peripheral = std::make_shared<platform::BxCanStmF4>(hcan1);
-
 	std::shared_ptr<platform::ICan> can_bus = bx_can_peripheral;
 
 	auto pe3_ecu = std::make_unique<sensor::Pe3>(can_bus);
+	const std::vector<uint32_t>& can_id_list = pe3_ecu->CanIdList();
+
+	// Subscribe to messages with PE3's CAN IDs
+	for (const uint32_t& can_id : can_id_list) {
+		bx_can_peripheral->ConfigureFilter(can_id, (can_id >> 13), (can_id & 0x1FFF));
+	}
+
+	bx_can_peripheral->Start();
 
 	bx_can_callback_ptr = bx_can_peripheral;
 	ReceiveInterruptMode rx_interrupt_mode = ReceiveInterruptMode::kFifo0MessagePending;

--- a/Project/Tests/Src/Sensor/ECU/PE3/pe_frames_tests.cpp
+++ b/Project/Tests/Src/Sensor/ECU/PE3/pe_frames_tests.cpp
@@ -483,15 +483,15 @@ TEST(Pe3EcuFrames, FramePe16) {
                                                 0x00, 0x00  };
     FramePE16 frame(rx_buffer);
 
-    static constexpr float kExpectedFuelCompAirTemp = 0.0f;
-    static constexpr float kExpectedFuelCompCoolantTemp = 1.0f;
-    static constexpr float kExpectedFuelCompBarometer = 0.0f;
-    static constexpr float kExpectedFuelCompMap = 0.0f;
+    static constexpr float kExpectedIgnitionCompAirTemp = 0.0f;
+    static constexpr float kExpectedIgnitionCompCoolantTemp = 1.0f;
+    static constexpr float kExpectedIgnitionCompBarometer = 0.0f;
+    static constexpr float kExpectedIgnitionCompMap = 0.0f;
 
-    EXPECT_FLOAT_EQ(frame.IgnitionCompensationAirTemperature(), kExpectedFuelCompAirTemp);
-    EXPECT_FLOAT_EQ(frame.IgnitionCompensationCoolantTemperature(), kExpectedFuelCompCoolantTemp);
-    EXPECT_FLOAT_EQ(frame.IgnitionCompensationBarometer(), kExpectedFuelCompBarometer);
-    EXPECT_FLOAT_EQ(frame.IgnitionCompensationManifoldAbsolutePressure(), kExpectedFuelCompMap);
+    EXPECT_FLOAT_EQ(frame.IgnitionCompensationAirTemperature(), kExpectedIgnitionCompAirTemp);
+    EXPECT_FLOAT_EQ(frame.IgnitionCompensationCoolantTemperature(), kExpectedIgnitionCompCoolantTemp);
+    EXPECT_FLOAT_EQ(frame.IgnitionCompensationBarometer(), kExpectedIgnitionCompBarometer);
+    EXPECT_FLOAT_EQ(frame.IgnitionCompensationManifoldAbsolutePressure(), kExpectedIgnitionCompMap);
 }
 
 }

--- a/Project/Tests/Src/Sensor/ECU/PE3/pe_frames_tests.cpp
+++ b/Project/Tests/Src/Sensor/ECU/PE3/pe_frames_tests.cpp
@@ -251,8 +251,8 @@ TEST(Pe3EcuFrames, FramePe7) {
     FramePE7 frame(rx_buffer);
 
     static constexpr float kExpectedVoltage = 68.0f;
-    EXPECT_FLOAT_EQ(frame.AnalogInputVoltage(0), kExpectedVoltage);
-    EXPECT_FLOAT_EQ(frame.AnalogInputVoltage(1), kExpectedVoltage);
+    EXPECT_FLOAT_EQ(frame.AnalogInputThermistorVoltage(0), kExpectedVoltage);
+    EXPECT_FLOAT_EQ(frame.AnalogInputThermistorVoltage(1), kExpectedVoltage);
 }
 
 TEST(Pe3EcuFrames, FramePe7OutOfBounds) {
@@ -266,8 +266,8 @@ TEST(Pe3EcuFrames, FramePe7OutOfBounds) {
     static constexpr float kExpecteResult = 0.0f;
     static constexpr uint8_t kMaxIndex = frame.kNumOfFields;
 
-    EXPECT_FLOAT_EQ(frame.AnalogInputVoltage(kMaxIndex + 1), kExpecteResult);
-    EXPECT_FLOAT_EQ(frame.AnalogInputVoltage(kMaxIndex + 2), kExpecteResult);
+    EXPECT_FLOAT_EQ(frame.AnalogInputThermistorVoltage(kMaxIndex + 1), kExpecteResult);
+    EXPECT_FLOAT_EQ(frame.AnalogInputThermistorVoltage(kMaxIndex + 2), kExpecteResult);
 }
 
 TEST(Pe3EcuFrames, FramePe8) {


### PR DESCRIPTION
### Summary
The final piece to integrating our ECU and CAN interfaces/libraries.

The `Pe3` library does **not** care about how the hardware is configured for reading data. It is up to the user to manage configuring the hardware for enabling polling or interrupt modes. Hardware configuration is done through the `bx_can_peripheral` pointer. However, `Pe3` interacts with it through the abstract interface `ICan` to be dependent on a CAN bus while being platform-independent.

There are a total of 3 pointers that are pointing to stm32's BxCAN hardware peripheral. For this reason, the peripheral is managed using `shared_ptr` instead of `unique_ptr`.

### Checks
- [x] Tested
