### PR TITLE
Updating CI Build to update its submodules after checkout

### DIFF
--- a/.github/workflows/ci_build.yaml
+++ b/.github/workflows/ci_build.yaml
@@ -14,6 +14,11 @@ jobs:
             uses: actions/checkout@v3
             with:
               submodules: 'true'
+
+          - name : Update the submodules
+            run: |
+              git submodule update --init --recursive
+              git submodule update --recursive --remote
           
           - name: Build stm32CubeIDE project
             uses: xanderhendriks/action-build-stm32cubeide@v10.0


### PR DESCRIPTION
### Summary

- Updated `#include` lines in `app.cpp` to support the new Platform layer sub-directories.
- Added a step to the CI Build to update the git submodules after checking it out.
